### PR TITLE
Image resizing in the mobilenet pilot

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -36,9 +36,9 @@ threshold_sonar_ft = 7.5
 [mobilenet]
 model_path="/home/pi/followme/detect_edgetpu.tflite"
 object_confidence = 0.5
-max_height = 520
+max_height = 510
 min_height = 75
-target_height = 450
+target_height = 470
 threaded_resize = False
 debug = True
 P = 0.8

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -36,9 +36,9 @@ threshold_sonar_ft = 7.5
 [mobilenet]
 model_path="/home/pi/followme/detect_edgetpu.tflite"
 object_confidence = 0.5
-max_height = 510
+max_height = 490
 min_height = 75
-target_height = 470
+target_height = 435
 threaded_resize = False
 debug = True
 P = 0.8

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -36,9 +36,9 @@ threshold_sonar_ft = 7.5
 [mobilenet]
 model_path="/home/pi/followme/detect_edgetpu.tflite"
 object_confidence = 0.5
-max_height = 490
-min_height = 75
-target_height = 435
+max_height = 0.96
+min_height = 0.15
+target_height = 0.85
 threaded_resize = False
 debug = True
 P = 0.8


### PR DESCRIPTION
Experimenting with performing cv2.resize in its own thread vs in series with the tensorflow evaluation and kalman filter.  cv2.resize using INTER_AREA, which I had been using because it offered the best image decimation, is also pretty expensive - 40-50ms or almost as much as the Google Coral delay.  I added an option to run this in its own thread, however, I have turned if off to use the INTER_NEAREST resize interpolation which seems to require only 1-4ms of delay.  It may produce inferior quality image resizing, but its fast and perhaps this doesn't really matter that much for person detection.  I will have to take the rover out to see how its performing.